### PR TITLE
fix: Rotate player marker direction -90 degrees for The Lab map

### DIFF
--- a/TarkovHelper/Pages/MapTrackerPage.xaml.cs
+++ b/TarkovHelper/Pages/MapTrackerPage.xaml.cs
@@ -806,7 +806,15 @@ public partial class MapTrackerPage : UserControl
             MarkerTranslation.Y = position.Y;
 
             // 방향 화살표 회전 (화살표만 회전, 중심 원은 고정)
-            MarkerRotation.Angle = position.Angle ?? 0;
+            var angle = position.Angle ?? 0;
+
+            // The Lab 맵은 방향을 왼쪽으로 90도 회전
+            if (string.Equals(_currentMapKey, "the-lab", StringComparison.OrdinalIgnoreCase))
+            {
+                angle -= 90;
+            }
+
+            MarkerRotation.Angle = angle;
         }
         else
         {


### PR DESCRIPTION
The Lab map requires a 90-degree left rotation adjustment for the player marker direction to correctly display the facing direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)